### PR TITLE
remove some defer and reduce memory allocation

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -168,7 +168,7 @@ func (t *Table) Close() error {
 // If it find an hash collision the last return value will be false,
 // which means caller should fallback to seek search. Otherwise it value will be true.
 // If the hash index does not contain such an element the returned key will be nil.
-func (t *Table) PointGet(key []byte) ([]byte, y.ValueStruct, bool) {
+func (t *Table) PointGet(it *Iterator, key []byte) ([]byte, y.ValueStruct, bool) {
 	keyNoTS := y.ParseKey(key)
 	blkIdx, offset := t.hIdx.lookup(keyNoTS)
 	if blkIdx == resultFallback {
@@ -178,9 +178,7 @@ func (t *Table) PointGet(key []byte) ([]byte, y.ValueStruct, bool) {
 		return nil, y.ValueStruct{}, true
 	}
 
-	it := t.NewIteratorNoRef(false)
 	it.seekFromOffset(int(blkIdx), int(offset), key)
-
 	if !it.Valid() || !y.SameKey(key, it.Key()) {
 		return nil, y.ValueStruct{}, true
 	}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -119,22 +119,23 @@ func TestHashIndexTS(t *testing.T) {
 		y.KeyWithTs([]byte("key"), 1),
 	}
 	for _, k := range keys {
-		b.Add(k, y.ValueStruct{Value: k, Meta: 'A', UserMeta: 0})
+		b.Add(k, y.ValueStruct{Value: k, Meta: 'A', UserMeta: []byte{0}})
 	}
 	f.Write(b.Finish())
 	f.Close()
 	f, _ = y.OpenSyncedFile(filename, true)
 	table, err := OpenTable(f, options.MemoryMap)
+	it := table.NewIteratorNoRef(false)
 
-	rk, _, ok := table.PointGet(y.KeyWithTs([]byte("key"), 10))
+	rk, _, ok := table.PointGet(it, y.KeyWithTs([]byte("key"), 10))
 	require.True(t, ok)
 	require.True(t, bytes.Compare(rk, keys[0]) == 0)
 
-	rk, _, ok = table.PointGet(y.KeyWithTs([]byte("key"), 6))
+	rk, _, ok = table.PointGet(it, y.KeyWithTs([]byte("key"), 6))
 	require.True(t, ok)
 	require.True(t, bytes.Compare(rk, keys[2]) == 0)
 
-	rk, _, ok = table.PointGet(y.KeyWithTs([]byte("key"), 2))
+	rk, _, ok = table.PointGet(it, y.KeyWithTs([]byte("key"), 2))
 	require.True(t, ok)
 	require.True(t, bytes.Compare(rk, keys[4]) == 0)
 }
@@ -147,7 +148,8 @@ func TestPointGet(t *testing.T) {
 
 	for i := 0; i < 8000; i++ {
 		k := y.KeyWithTs([]byte(key("key", i)), math.MaxUint64)
-		k, _, ok := table.PointGet(k)
+		it := table.NewIteratorNoRef(false)
+		k, _, ok := table.PointGet(it, k)
 		if !ok {
 			// will fallback to seek
 			continue
@@ -158,7 +160,8 @@ func TestPointGet(t *testing.T) {
 
 	for i := 8000; i < 10000; i++ {
 		k := y.KeyWithTs([]byte(key("key", i)), math.MaxUint64)
-		rk, _, ok := table.PointGet(k)
+		it := table.NewIteratorNoRef(false)
+		rk, _, ok := table.PointGet(it, k)
 		if !ok {
 			// will fallback to seek
 			continue
@@ -742,7 +745,7 @@ func BenchmarkBuildTable(b *testing.B) {
 			for bn := 0; bn < b.N; bn++ {
 				builder := NewTableBuilder(0, options.TableBuilderOptions{EnableHashIndex: false})
 				for i := 0; i < n; i++ {
-					y.Check(builder.Add(kvs[i].k, y.ValueStruct{Value: kvs[i].v, Meta: 123, UserMeta: 0}))
+					y.Check(builder.Add(kvs[i].k, y.ValueStruct{Value: kvs[i].v, Meta: 123, UserMeta: []byte{0}}))
 				}
 				result = builder.Finish()
 			}
@@ -754,7 +757,7 @@ func BenchmarkBuildTable(b *testing.B) {
 			for bn := 0; bn < b.N; bn++ {
 				builder := NewTableBuilder(0, defaultBuilderOpt)
 				for i := 0; i < n; i++ {
-					y.Check(builder.Add(kvs[i].k, y.ValueStruct{Value: kvs[i].v, Meta: 123, UserMeta: 0}))
+					y.Check(builder.Add(kvs[i].k, y.ValueStruct{Value: kvs[i].v, Meta: 123, UserMeta: []byte{0}}))
 				}
 				result = builder.Finish()
 			}
@@ -775,7 +778,7 @@ func BenchmarkPointGet(b *testing.B) {
 			k := y.KeyWithTs([]byte(fmt.Sprintf("%016x", i)), 0)
 			v := fmt.Sprintf("%d", i)
 			keys[i] = k
-			y.Check(builder.Add([]byte(k), y.ValueStruct{Value: []byte(v), Meta: 123, UserMeta: 0}))
+			y.Check(builder.Add([]byte(k), y.ValueStruct{Value: []byte(v), Meta: 123, UserMeta: []byte{0}}))
 		}
 
 		f.Write(builder.Finish())
@@ -798,27 +801,30 @@ func BenchmarkPointGet(b *testing.B) {
 					if !y.SameKey(k, it.Key()) {
 						continue
 					}
-					vs = it.Value()
+					if version := y.ParseTs(it.Key()); vs.Version < version {
+						vs = it.Value()
+					}
 				}
 			}
 			_ = vs
 		})
 
 		b.Run(fmt.Sprintf("Hash_%d", n), func(b *testing.B) {
-			var (
-				resultKey []byte
-				resultVs  y.ValueStruct
-				ok        bool
-			)
+			var vs y.ValueStruct
 			rand := rand.New(rand.NewSource(0))
 			for bn := 0; bn < b.N; bn++ {
 				rand.Seed(0)
 				for i := 0; i < n; i++ {
+					var (
+						resultKey []byte
+						resultVs  y.ValueStruct
+						ok        bool
+					)
 					k := keys[rand.Intn(n)]
 
-					resultKey, resultVs, ok = tbl.PointGet(k)
+					it := tbl.NewIteratorNoRef(false)
+					resultKey, resultVs, ok = tbl.PointGet(it, k)
 					if !ok {
-						it := tbl.NewIteratorNoRef(false)
 						it.Seek(k)
 						if !it.Valid() {
 							continue
@@ -828,9 +834,13 @@ func BenchmarkPointGet(b *testing.B) {
 						}
 						resultKey, resultVs = it.Key(), it.Value()
 					}
+
+					if version := y.ParseTs(resultKey); vs.Version < version {
+						vs = resultVs
+					}
 				}
 			}
-			_, _ = resultKey, resultVs
+			_ = vs
 		})
 
 		tbl.DecrRef()


### PR DESCRIPTION
`pprof` shows `defer` in `get` and `getTableForKey` takes lots of time, so remove them in these two function.

Due to limitation of Go Compiler's escape analysis, the `itr.key = itr.keyBuf[:0]` will cause the whole `blockIterator` escape to heap. https://github.com/golang/go/issues/7921#issuecomment-285855447.

After some refactor, we can avoid this allocation when key length less than 32 bytes. The benchmark result is

Before:
```
BenchmarkPointGet/Seek_1000-12         	   20000	    453132 ns/op	  448000 B/op	    1000 allocs/op
BenchmarkPointGet/Hash_1000-12         	   20000	    391929 ns/op	  448000 B/op	    1000 allocs/op
BenchmarkPointGet/Seek_10000-12        	    2000	   5529729 ns/op	 4480002 B/op	   10000 allocs/op
BenchmarkPointGet/Hash_10000-12        	    2000	   4623209 ns/op	 4480002 B/op	   10000 allocs/op
BenchmarkPointGet/Seek_100000-12       	     100	  87278133 ns/op	44800053 B/op	  100000 allocs/op
BenchmarkPointGet/Hash_100000-12       	     100	  76633040 ns/op	44800053 B/op	  100000 allocs/op
BenchmarkPointGet/Seek_1000000-12      	       5	1420931867 ns/op	448001075 B/op	 1000000 allocs/op
BenchmarkPointGet/Hash_1000000-12      	       5	1210990874 ns/op	448001075 B/op	 1000000 allocs/op
BenchmarkPointGet/Seek_5000000-12      	       1	8763558217 ns/op	2240005376 B/op	 5000001 allocs/op
BenchmarkPointGet/Hash_5000000-12      	       1	7088176634 ns/op	2240005376 B/op	 5000001 allocs/op
BenchmarkPointGet/Seek_10000000-12     	       1	18787675792 ns/op	4480005376 B/op	10000001 allocs/op
BenchmarkPointGet/Hash_10000000-12     	       1	15630159271 ns/op	4480005376 B/op	10000001 allocs/op
BenchmarkPointGet/Seek_15000000-12     	       1	29897498825 ns/op	6720005376 B/op	15000001 allocs/op
BenchmarkPointGet/Hash_15000000-12     	       1	25130976701 ns/op	6720005376 B/op	15000001 allocs/op
```

After:
```
BenchmarkPointGet/Seek_1000-12         	   20000	    374426 ns/op	       0 B/op	       0 allocs/op
BenchmarkPointGet/Hash_1000-12         	   30000	    299675 ns/op	       0 B/op	       0 allocs/op
BenchmarkPointGet/Seek_10000-12        	    2000	   4554433 ns/op	       2 B/op	       0 allocs/op
BenchmarkPointGet/Hash_10000-12        	    2000	   3519133 ns/op	       2 B/op	       0 allocs/op
BenchmarkPointGet/Seek_100000-12       	     100	  63780739 ns/op	      53 B/op	       0 allocs/op
BenchmarkPointGet/Hash_100000-12       	     100	  53004132 ns/op	      53 B/op	       0 allocs/op
BenchmarkPointGet/Seek_1000000-12      	       5	1254546150 ns/op	    1075 B/op	       0 allocs/op
BenchmarkPointGet/Hash_1000000-12      	       5	1063565797 ns/op	    1075 B/op	       0 allocs/op
BenchmarkPointGet/Seek_5000000-12      	       1	8397103129 ns/op	    5376 B/op	       1 allocs/op
BenchmarkPointGet/Hash_5000000-12      	       1	6564546701 ns/op	    5376 B/op	       1 allocs/op
BenchmarkPointGet/Seek_10000000-12     	       1	18007819630 ns/op	    5376 B/op	       1 allocs/op
BenchmarkPointGet/Hash_10000000-12     	       1	14948745975 ns/op	    5376 B/op	       1 allocs/op
BenchmarkPointGet/Seek_15000000-12     	       1	29151195895 ns/op	    5376 B/op	       1 allocs/op
BenchmarkPointGet/Hash_15000000-12     	       1	24251887305 ns/op	    5376 B/op	       1 allocs/op
```