### PR TITLE
Revert "support seek by uint64 in SST (#196)"

### DIFF
--- a/table/sstable/builder.go
+++ b/table/sstable/builder.go
@@ -113,8 +113,6 @@ type Builder struct {
 
 	singleKeyOldVers entrySlice
 	oldBlock         []byte
-
-	keyDiffs []uint64
 }
 
 // NewTableBuilder makes a new TableBuilder.
@@ -260,15 +258,11 @@ func (b *Builder) finishBlock() error {
 	}
 	firstKey := b.tmpKeys.getEntry(0)
 	lastKey := b.tmpKeys.getLast()
-	baseLen := keyDiffIdx(firstKey, lastKey)
+	blockCommonLen := keyDiffIdx(firstKey, lastKey)
 	for i := 0; i < b.tmpKeys.length(); i++ {
 		key := b.tmpKeys.getEntry(i)
-		keyDiff := extractKeyDiff(key, baseLen)
-		b.keyDiffs = append(b.keyDiffs, keyDiff)
-		keyDiffLen := int(byte(keyDiff))
-		keySuffix := key[baseLen+keyDiffLen:]
-		b.buf = appendU16(b.buf, uint16(len(keySuffix)))
-		b.buf = append(b.buf, keySuffix...)
+		b.buf = appendU16(b.buf, uint16(len(key)-blockCommonLen))
+		b.buf = append(b.buf, key[blockCommonLen:]...)
 		if b.tmpOldOffs[i] == 0 {
 			b.buf = append(b.buf, 0)
 		} else {
@@ -278,10 +272,9 @@ func (b *Builder) finishBlock() error {
 		b.buf = append(b.buf, b.tmpVals.getEntry(i)...)
 		b.entryEndOffsets = append(b.entryEndOffsets, uint32(len(b.buf)))
 	}
-	b.buf = append(b.buf, u64SliceToBytes(b.keyDiffs)...)
 	b.buf = append(b.buf, u32SliceToBytes(b.entryEndOffsets)...)
 	b.buf = append(b.buf, u32ToBytes(uint32(len(b.entryEndOffsets)))...)
-	b.buf = appendU16(b.buf, uint16(baseLen))
+	b.buf = appendU16(b.buf, uint16(blockCommonLen))
 
 	// Add base key.
 	b.baseKeys.append(firstKey)
@@ -302,7 +295,6 @@ func (b *Builder) finishBlock() error {
 	b.tmpKeys.reset()
 	b.tmpVals.reset()
 	b.tmpOldOffs = b.tmpOldOffs[:0]
-	b.keyDiffs = b.keyDiffs[:0]
 	return nil
 }
 
@@ -373,7 +365,6 @@ const (
 	idHashIndex
 	idSuRFIndex
 	idOldBlockLen
-	idBaseKeyDiffs
 )
 
 // Finish finishes the table by appending the index.
@@ -408,7 +399,6 @@ func (b *Builder) Finish() error {
 	encoder.append(b.smallest.UserKey, idSmallest)
 	encoder.append(b.biggest.UserKey, idBiggest)
 	encoder.append(u32SliceToBytes(b.baseKeys.endOffs), idBaseKeysEndOffs)
-	encoder.append(u64SliceToBytes(b.getBaseKeyDiffs()), idBaseKeyDiffs)
 	encoder.append(b.baseKeys.data, idBaseKeys)
 	encoder.append(u32SliceToBytes(b.blockEndOffsets), idBlockEndOffsets)
 	if len(b.oldBlock) > 1 {
@@ -446,16 +436,6 @@ func (b *Builder) Finish() error {
 	}
 
 	return b.w.Finish()
-}
-
-func (b *Builder) getBaseKeyDiffs() []uint64 {
-	commonLen := keyDiffIdx(b.smallest.UserKey, b.biggest.UserKey)
-	baseKeyDiffs := make([]uint64, b.baseKeys.length())
-	for i := 0; i < b.baseKeys.length(); i++ {
-		key := b.baseKeys.getEntry(i)
-		baseKeyDiffs[i] = extractKeyDiff(key, commonLen)
-	}
-	return baseKeyDiffs
 }
 
 func appendU16(buf []byte, v uint16) []byte {
@@ -496,30 +476,6 @@ func bytesToU32Slice(b []byte) []uint32 {
 	hdr.Cap = hdr.Len
 	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
 	return u32s
-}
-
-func u64SliceToBytes(u64s []uint64) []byte {
-	if len(u64s) == 0 {
-		return nil
-	}
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Len = len(u64s) * 8
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&u64s[0]))
-	return b
-}
-
-func bytesToU64Slice(b []byte) []uint64 {
-	if len(b) == 0 {
-		return nil
-	}
-	var u64s []uint64
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u64s))
-	hdr.Len = len(b) / 8
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
-	return u64s
 }
 
 func bytesToU32(b []byte) uint32 {

--- a/table/sstable/table.go
+++ b/table/sstable/table.go
@@ -53,7 +53,6 @@ type tableIndex struct {
 	bf              *bbloom.Bloom
 	hIdx            *hashIndex
 	surf            *surf.SuRF
-	baseKeyDiffs    []uint64
 }
 
 // Table represents a loaded table file with the info we have about it
@@ -83,7 +82,6 @@ type Table struct {
 
 	oldBlockLen int64
 	oldBlock    []byte
-	commonLen   int
 }
 
 // CompressionType returns the compression algorithm used for block compression.
@@ -241,7 +239,7 @@ func (t *Table) pointGet(key y.Key, keyHash uint64) (y.Key, y.ValueStruct, bool,
 	}
 
 	it := t.newIterator(false)
-	it.err = it.seekFromOffset(int(blkIdx), int(offset), key.UserKey)
+	it.seekFromOffset(int(blkIdx), int(offset), key.UserKey)
 
 	if !it.Valid() || !key.SameUserKey(it.Key()) {
 		return y.Key{}, y.ValueStruct{}, true, it.Error()
@@ -292,7 +290,6 @@ func (t *Table) initTableInfo() error {
 			t.tableSize += t.oldBlockLen
 		}
 	}
-	t.commonLen = keyDiffIdx(t.smallest.UserKey, t.biggest.UserKey)
 	return nil
 }
 
@@ -321,8 +318,6 @@ func (t *Table) readTableIndex(d *metaDecoder) *tableIndex {
 				idx.surf = new(surf.SuRF)
 				idx.surf.Unmarshal(d)
 			}
-		case idBaseKeyDiffs:
-			idx.baseKeyDiffs = bytesToU64Slice(d.decode())
 		}
 	}
 	return idx


### PR DESCRIPTION
This reverts commit 0244807ae70df8956661ca4cc7df3d68078e3eea.

The implementation has some bug cause panic.

And it's not suited for clustered index feature because the row key diff may vary a lot.