### PR TITLE
fix badger cannot start after KILL on Windows

### DIFF
--- a/dir_windows.go
+++ b/dir_windows.go
@@ -24,8 +24,10 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"unsafe"
 
 	"github.com/pingcap/errors"
+	"golang.org/x/sys/windows"
 )
 
 func openDir(path string) (*os.File, error) {
@@ -53,15 +55,11 @@ func openDirWin(path string) (fd syscall.Handle, err error) {
 
 // DirectoryLockGuard holds a lock on the directory.
 type directoryLockGuard struct {
-	path string
+	fd *os.File
 }
 
 // AcquireDirectoryLock acquires exclusive access to a directory.
 func acquireDirectoryLock(dirPath string, pidFileName string, readOnly bool) (*directoryLockGuard, error) {
-	if readOnly {
-		return nil, ErrWindowsNotSupported
-	}
-
 	// Convert to absolute path so that Release still works even if we do an unbalanced
 	// chdir in the meantime.
 	absLockFilePath, err := filepath.Abs(filepath.Join(dirPath, pidFileName))
@@ -69,26 +67,68 @@ func acquireDirectoryLock(dirPath string, pidFileName string, readOnly bool) (*d
 		return nil, errors.Wrap(err, "Cannot get absolute path for pid lock file")
 	}
 
-	f, err := os.OpenFile(absLockFilePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	file, err := createFileAndLock(absLockFilePath, readOnly, false)
 	if err != nil {
-		return nil, errors.Wrapf(err,
-			"Cannot create pid lock file %q.  Another process is using this Badger database",
-			absLockFilePath)
+		return nil, err
 	}
-	_, err = fmt.Fprintf(f, "%d\n", os.Getpid())
-	closeErr := f.Close()
+	if file == nil {
+		file, err = createFileAndLock(absLockFilePath, readOnly, true)
+	}
 	if err != nil {
-		return nil, errors.Wrap(err, "Cannot write to pid lock file")
+		return nil, err
 	}
-	if closeErr != nil {
-		return nil, errors.Wrap(closeErr, "Cannot close pid lock file")
+
+	if !readOnly {
+		_, err = file.WriteAt([]byte(fmt.Sprintf("%d\n", os.Getpid())), 0)
+		if err != nil {
+			_ = file.Close()
+			return nil, errors.Wrap(err, "Cannot write to pid lock file")
+		}
 	}
-	return &directoryLockGuard{path: absLockFilePath}, nil
+	return &directoryLockGuard{fd: file}, nil
+}
+
+var (
+	mod  = windows.NewLazyDLL("kernel32.dll")
+	proc = mod.NewProc("CreateFileW")
+)
+
+func createFileAndLock(path string, share bool, create bool) (*os.File, error) {
+	dwShareMode := uint32(0) // Exclusive (no sharing)
+	if share {
+		dwShareMode = windows.FILE_SHARE_READ
+	}
+	op := windows.OPEN_EXISTING
+	if create {
+		op = windows.CREATE_NEW
+	}
+
+	a, _, err := proc.Call(
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(path))),
+		uintptr(windows.GENERIC_READ|windows.GENERIC_WRITE),
+		uintptr(dwShareMode),
+		uintptr(0), // No security attributes.
+		uintptr(op),
+		uintptr(windows.FILE_ATTRIBUTE_NORMAL),
+		0, // No template file.
+	)
+	switch err.(windows.Errno) {
+	case 0:
+		return os.NewFile(a, path), nil
+	case windows.ERROR_FILE_NOT_FOUND:
+		return nil, nil
+	case windows.ERROR_SHARING_VIOLATION, windows.ERROR_FILE_EXISTS:
+		return nil, errors.New(fmt.Sprintf("Cannot acquire directory lock on %q, Another process is using this Badger database.", path))
+	default:
+		_ = windows.Close(windows.Handle(a))
+		return nil, errors.WithStack(err)
+	}
 }
 
 // Release removes the directory lock.
 func (g *directoryLockGuard) release() error {
-	path := g.path
-	g.path = ""
-	return os.Remove(path)
+	if g.fd == nil {
+		return nil
+	}
+	return g.fd.Close()
 }


### PR DESCRIPTION
The file lock implementation on win32 platform is incorrect, the lock cannot be released after the process is killed.

The `windows.CreateFile` doesn't handle win32 errors correctly, so I have to use my own wrapper.