### PR TITLE
support build and open in-memory SST

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -16,7 +16,7 @@ func TestBlob(t *testing.T) {
 	defer os.RemoveAll(dir)
 	opts := getTestOptions(dir)
 	opts.ValueThreshold = 20
-	opts.MaxTableSize = 4 * 1024
+	opts.TableBuilderOptions.MaxTableSize = 4 * 1024
 	opts.MaxMemTableSize = 4 * 1024
 	opts.NumMemtables = 2
 	opts.NumLevelZeroTables = 1
@@ -70,7 +70,7 @@ func TestBlobGC(t *testing.T) {
 	defer os.RemoveAll(dir)
 	opts := getTestOptions(dir)
 	opts.ValueThreshold = 20
-	opts.MaxTableSize = 6 * 1024
+	opts.TableBuilderOptions.MaxTableSize = 6 * 1024
 	opts.MaxMemTableSize = 6 * 1024
 	opts.NumMemtables = 2
 	opts.NumLevelZeroTables = 1

--- a/compaction.go
+++ b/compaction.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pingcap/badger/options"
 	"github.com/pingcap/badger/table"
+	"github.com/pingcap/badger/table/sstable"
 	"github.com/pingcap/badger/y"
 	"golang.org/x/time/rate"
 )
@@ -220,12 +221,12 @@ type CompactDef struct {
 	SafeTS      uint64
 	Guards      []Guard
 	Filter      CompactionFilter
-	MaxTblSize  int64
 	HasOverlap  bool
 	Opt         options.TableBuilderOptions
 	Dir         string
 	AllocIDFunc func() uint64
 	Limiter     *rate.Limiter
+	InMemory    bool
 
 	splitHints []y.Key
 
@@ -483,12 +484,12 @@ func (cd *CompactDef) buildIterator() y.Iterator {
 }
 
 type compactor interface {
-	compact(cd *CompactDef, stats *y.CompactionStats, discardStats *DiscardStats) ([]string, error)
+	compact(cd *CompactDef, stats *y.CompactionStats, discardStats *DiscardStats) ([]*sstable.BuildResult, error)
 }
 
 type localCompactor struct {
 }
 
-func (c *localCompactor) compact(cd *CompactDef, stats *y.CompactionStats, discardStats *DiscardStats) ([]string, error) {
+func (c *localCompactor) compact(cd *CompactDef, stats *y.CompactionStats, discardStats *DiscardStats) ([]*sstable.BuildResult, error) {
 	return CompactTables(cd, stats, discardStats)
 }

--- a/db.go
+++ b/db.go
@@ -289,7 +289,7 @@ func Open(opt Options) (db *DB, err error) {
 			return nil, errors.Wrap(err, "failed to create block cache")
 		}
 
-		indexSizeHint := float64(opt.MaxTableSize) / 6.0
+		indexSizeHint := float64(opt.TableBuilderOptions.MaxTableSize) / 6.0
 		idxCache, err = cache.NewCache(&cache.Config{
 			NumCounters: int64(float64(opt.MaxIndexCacheSize) / indexSizeHint * 10),
 			MaxCost:     opt.MaxIndexCacheSize,
@@ -860,7 +860,7 @@ func (db *DB) writeLevel0Table(s *memtable.Table, f *os.File) error {
 			value.Meta |= bitValuePointer
 			value.Value = bp
 		}
-		if err := b.Add(key, value); err != nil {
+		if err = b.Add(key, value); err != nil {
 			return err
 		}
 		numWrite++
@@ -872,7 +872,7 @@ func (db *DB) writeLevel0Table(s *memtable.Table, f *os.File) error {
 	}
 	db.lc.levels[0].metrics.UpdateCompactionStats(stats)
 
-	if err := b.Finish(); err != nil {
+	if _, err = b.Finish(); err != nil {
 		return y.Wrap(err)
 	}
 	if bb != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -50,9 +50,9 @@ func getTestCompression(tp options.CompressionType) []options.CompressionType {
 
 func getTestOptions(dir string) Options {
 	opt := DefaultOptions
-	opt.MaxTableSize = 4 << 15    // Force more compaction.
-	opt.MaxMemTableSize = 4 << 15 // Force more compaction.
-	opt.LevelOneSize = 4 << 15    // Force more compaction.
+	opt.TableBuilderOptions.MaxTableSize = 4 << 15 // Force more compaction.
+	opt.MaxMemTableSize = 4 << 15                  // Force more compaction.
+	opt.LevelOneSize = 4 << 15                     // Force more compaction.
 	opt.Dir = dir
 	opt.ValueDir = dir
 	opt.SyncWrites = false
@@ -1161,7 +1161,7 @@ func TestCompactionFilter(t *testing.T) {
 	defer os.RemoveAll(dir)
 	opts := getTestOptions(dir)
 	opts.ValueThreshold = 8 * 1024
-	opts.MaxTableSize = 32 * 1024
+	opts.TableBuilderOptions.MaxTableSize = 32 * 1024
 	opts.MaxMemTableSize = 32 * 1024
 	opts.NumMemtables = 2
 	opts.NumLevelZeroTables = 1
@@ -1298,7 +1298,7 @@ func TestIterateVLog(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	opts := getTestOptions(dir)
-	opts.MaxTableSize = 1 << 20
+	opts.TableBuilderOptions.MaxTableSize = 1 << 20
 	opts.MaxMemTableSize = 1 << 20
 	opts.ValueLogFileSize = 1 << 20
 	opts.ValueThreshold = 1000
@@ -1405,7 +1405,8 @@ func buildSst(t *testing.T, keys [][]byte, vals [][]byte) *os.File {
 		err := builder.Add(y.KeyWithTs(k, 0), y.ValueStruct{Value: vals[i], Meta: 0, UserMeta: []byte{0}})
 		require.NoError(t, err)
 	}
-	require.NoError(t, builder.Finish())
+	_, err = builder.Finish()
+	require.NoError(t, err)
 	return f
 }
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -163,7 +163,8 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 			y.Check(err)
 		}
 	}
-	y.Check(b.Finish())
+	_, err = b.Finish()
+	y.Check(err)
 	f.Close()
 	f, _ = y.OpenSyncedFile(filename, true)
 	return f

--- a/options.go
+++ b/options.go
@@ -47,7 +47,6 @@ type Options struct {
 	// ----------------------------------------
 	// The following affect all levels of LSM tree.
 	MaxMemTableSize int64 // Each mem table is at most this size.
-	MaxTableSize    int64 // Each table file is at most this size.
 	// If value size >= this threshold, only store value offsets in tree.
 	// If set to 0, all values are stored in SST.
 	ValueThreshold int
@@ -148,7 +147,6 @@ var DefaultOptions = Options{
 	DoNotCompact:            false,
 	LevelOneSize:            256 << 20,
 	MaxMemTableSize:         64 << 20,
-	MaxTableSize:            8 << 20,
 	NumCompactors:           3,
 	NumLevelZeroTables:      5,
 	NumLevelZeroTablesStall: 10,
@@ -162,6 +160,7 @@ var DefaultOptions = Options{
 	MaxBlockCacheSize:       1 << 30,
 	MaxIndexCacheSize:       1 << 30,
 	TableBuilderOptions: options.TableBuilderOptions{
+		MaxTableSize:        8 << 20,
 		SuRFStartLevel:      8,
 		HashUtilRatio:       0.75,
 		WriteBufferSize:     2 * 1024 * 1024,

--- a/options/options.go
+++ b/options/options.go
@@ -98,6 +98,7 @@ type TableBuilderOptions struct {
 	CompressionPerLevel []CompressionType
 	SuRFStartLevel      int
 	SuRFOptions         SuRFOptions
+	MaxTableSize        int64
 }
 
 type SuRFOptions struct {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -778,7 +778,7 @@ func TestArmV7Issue311Fix(t *testing.T) {
 	config := DefaultOptions
 	config.ValueLogFileSize = 16 << 20
 	config.LevelOneSize = 8 << 20
-	config.MaxTableSize = 2 << 20
+	config.TableBuilderOptions.MaxTableSize = 2 << 20
 	config.MaxMemTableSize = 2 << 20
 	config.Dir = dir
 	config.ValueDir = dir


### PR DESCRIPTION
So remote compaction doesn't need to read and write files.