### PR TITLE
Reuse buffer and fix a deadlock in levelsController

### DIFF
--- a/db.go
+++ b/db.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/dgryski/go-farm"
-	"github.com/ncw/directio"
 	"github.com/pingcap/badger/cache"
 	"github.com/pingcap/badger/epoch"
 	"github.com/pingcap/badger/options"
@@ -38,6 +37,7 @@ import (
 	"github.com/pingcap/badger/table/memtable"
 	"github.com/pingcap/badger/table/sstable"
 	"github.com/pingcap/badger/y"
+	"github.com/ncw/directio"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -284,6 +284,7 @@ func Open(opt Options) (db *DB, err error) {
 			NumCounters: opt.MaxBlockCacheSize / int64(opt.TableBuilderOptions.BlockSize) * 10,
 			MaxCost:     opt.MaxBlockCacheSize,
 			BufferItems: 64,
+			OnEvict:     sstable.OnEvict,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create block cache")

--- a/db.go
+++ b/db.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/dgryski/go-farm"
+	"github.com/ncw/directio"
 	"github.com/pingcap/badger/cache"
 	"github.com/pingcap/badger/epoch"
 	"github.com/pingcap/badger/options"
@@ -37,7 +38,6 @@ import (
 	"github.com/pingcap/badger/table/memtable"
 	"github.com/pingcap/badger/table/sstable"
 	"github.com/pingcap/badger/y"
-	"github.com/ncw/directio"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -454,6 +454,7 @@ func (db *DB) DeleteFilesInRange(start, end []byte) {
 			discardStats.collect(it.Value())
 		}
 		deletes[i] = tbl
+		it.Close()
 	}
 	if len(discardStats.ptrs) > 0 {
 		db.blobManger.discardCh <- &discardStats
@@ -836,6 +837,7 @@ func arenaSize(opt Options) int64 {
 // WriteLevel0Table flushes memtable. It drops deleteValues.
 func (db *DB) writeLevel0Table(s *memtable.Table, f *os.File) error {
 	iter := s.NewIterator(false)
+	defer iter.Close()
 	var (
 		bb                   *blobFileBuilder
 		numWrite, bytesWrite int

--- a/db_test.go
+++ b/db_test.go
@@ -632,7 +632,6 @@ func TestIterateDeleted(t *testing.T) {
 
 		txn := db.NewTransaction(false)
 		idxIt := txn.NewIterator(DefaultIteratorOptions)
-		defer idxIt.Close()
 
 		count := 0
 		txn2 := db.NewTransaction(true)
@@ -646,11 +645,10 @@ func TestIterateDeleted(t *testing.T) {
 		}
 		require.Equal(t, 2, count)
 		require.NoError(t, txn2.Commit())
-
+		idxIt.Close()
 		t.Run(fmt.Sprintf("Prefetch=%t", false), func(t *testing.T) {
 			txn := db.NewTransaction(false)
-			idxIt = txn.NewIterator(DefaultIteratorOptions)
-
+			idxIt := txn.NewIterator(DefaultIteratorOptions)
 			var estSize int64
 			var idxKeys []string
 			for idxIt.Seek(prefix); idxIt.Valid(); idxIt.Next() {
@@ -665,6 +663,7 @@ func TestIterateDeleted(t *testing.T) {
 			}
 			require.Equal(t, 0, len(idxKeys))
 			require.Equal(t, int64(0), estSize)
+			idxIt.Close()
 		})
 	})
 }
@@ -762,6 +761,7 @@ func TestSetIfAbsentAsync(t *testing.T) {
 	txn := kv.NewTransaction(false)
 	var count int
 	it := txn.NewIterator(DefaultIteratorOptions)
+	defer it.Close()
 	{
 		t.Log("Starting first basic iteration")
 		for it.Rewind(); it.Valid(); it.Next() {

--- a/iterator.go
+++ b/iterator.go
@@ -259,6 +259,8 @@ type Iterator struct {
 	item  *Item
 	itBuf Item
 	vs    y.ValueStruct
+
+	closed bool
 }
 
 // NewIterator returns a new iterator. Depending upon the options, either only keys, or both
@@ -318,6 +320,11 @@ func (it *Iterator) ValidForPrefix(prefix []byte) bool {
 
 // Close would close the iterator. It is important to call this when you're done with iteration.
 func (it *Iterator) Close() {
+	if it.closed {
+		return
+	}
+	it.closed = true
+	it.iitr.Close()
 	atomic.AddInt32(&it.txn.numIterators, -1)
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -197,6 +197,7 @@ func (opts *IteratorOptions) OverlapMemTable(t *memtable.Table) bool {
 		return true
 	}
 	iter := t.NewIterator(false)
+	defer iter.Close()
 	iter.Seek(opts.StartKey.UserKey)
 	if !iter.Valid() {
 		return false

--- a/levels.go
+++ b/levels.go
@@ -688,12 +688,13 @@ func (lc *levelsController) addLevel0Table(t table.Table, head *protos.HeadInfo)
 		var timeStart time.Time
 		{
 			log.Warn("STALLED STALLED STALLED", zap.Duration("duration", time.Since(lastUnstalled)))
-			lc.cstatus.RLock()
 			for i := 0; i < lc.kv.opt.TableBuilderOptions.MaxLevels; i++ {
-				log.Warn("dump level status", zap.Int("level", i), zap.String("status", lc.cstatus.levels[i].debug()),
+				lc.cstatus.RLock()
+				status := lc.cstatus.levels[i].debug()
+				lc.cstatus.RUnlock()
+				log.Warn("dump level status", zap.Int("level", i), zap.String("status", status),
 					zap.Int64("size", lc.levels[i].getTotalSize()))
 			}
-			lc.cstatus.RUnlock()
 			timeStart = time.Now()
 		}
 		// Before we unstall, we need to make sure that level 0 is healthy. Otherwise, we

--- a/levels.go
+++ b/levels.go
@@ -408,6 +408,7 @@ func (lc *levelsController) compactBuildTables(cd *CompactDef) (newTables []tabl
 func CompactTables(cd *CompactDef, stats *y.CompactionStats, discardStats *DiscardStats) ([]*sstable.BuildResult, error) {
 	var buildResults []*sstable.BuildResult
 	it := cd.buildIterator()
+	defer it.Close()
 
 	skippedTbls := cd.SkippedTbls
 	splitHints := cd.splitHints

--- a/options/options.go
+++ b/options/options.go
@@ -23,8 +23,8 @@ import (
 	"io/ioutil"
 
 	"github.com/golang/snappy"
-	"github.com/pingcap/badger/buffer"
 	"github.com/klauspost/compress/zstd"
+	"github.com/pingcap/badger/buffer"
 )
 
 // CompressionType specifies how a block should be compressed.

--- a/table/concat_iterator.go
+++ b/table/concat_iterator.go
@@ -123,3 +123,16 @@ func (s *ConcatIterator) Next() {
 func (s *ConcatIterator) NextVersion() bool {
 	return s.cur.NextVersion()
 }
+
+// Close implements y.Interface.
+func (s *ConcatIterator) Close() error {
+	for _, it := range s.iters {
+		if it == nil {
+			continue
+		}
+		if err := it.Close(); err != nil {
+			return y.Wrapf(err, "ConcatIterator")
+		}
+	}
+	return nil
+}

--- a/table/memtable/skl.go
+++ b/table/memtable/skl.go
@@ -713,3 +713,5 @@ func (s *UniIterator) FillValue(vs *y.ValueStruct) { s.iter.FillValue(vs) }
 
 // Valid implements y.Interface
 func (s *UniIterator) Valid() bool { return s.iter.Valid() }
+
+func (s *UniIterator) Close() error { return nil }

--- a/table/memtable/skl.go
+++ b/table/memtable/skl.go
@@ -655,6 +655,10 @@ func (s *Iterator) SeekToLast() {
 	s.loadNode()
 }
 
+func (s *Iterator) Close() error {
+	return nil
+}
+
 // UniIterator is a unidirectional memtable iterator. It is a thin wrapper around
 // Iterator. We like to keep Iterator as before, because it is more powerful and
 // we might support bidirectional iterators in the future.
@@ -714,4 +718,4 @@ func (s *UniIterator) FillValue(vs *y.ValueStruct) { s.iter.FillValue(vs) }
 // Valid implements y.Interface
 func (s *UniIterator) Valid() bool { return s.iter.Valid() }
 
-func (s *UniIterator) Close() error { return nil }
+func (s *UniIterator) Close() error { return s.iter.Close() }

--- a/table/memtable/skl_test.go
+++ b/table/memtable/skl_test.go
@@ -74,6 +74,7 @@ func TestEmpty(t *testing.T) {
 
 	it.Seek(key)
 	require.False(t, it.Valid())
+	it.Close()
 }
 
 // TestBasic tests single-threaded inserts and updates and gets.
@@ -255,6 +256,7 @@ func TestIteratorNext(t *testing.T) {
 	l := newSkiplist(arenaSize)
 	defer l.Delete()
 	it := l.NewIterator()
+	defer it.Close()
 	require.False(t, it.Valid())
 	it.SeekToFirst()
 	require.False(t, it.Valid())
@@ -278,6 +280,7 @@ func TestIteratorPrev(t *testing.T) {
 	l := newSkiplist(arenaSize)
 	defer l.Delete()
 	it := l.NewIterator()
+	defer it.Close()
 	require.False(t, it.Valid())
 	it.SeekToFirst()
 	require.False(t, it.Valid())
@@ -302,7 +305,7 @@ func TestIteratorSeek(t *testing.T) {
 	defer l.Delete()
 
 	it := l.NewIterator()
-
+	defer it.Close()
 	require.False(t, it.Valid())
 	it.SeekToFirst()
 	require.False(t, it.Valid())
@@ -373,6 +376,7 @@ func TestPutWithHint(t *testing.T) {
 		cnt++
 	}
 	it := l.NewIterator()
+	defer it.Close()
 	var lastKey y.Key
 	cntGot := 0
 	for it.SeekToFirst(); it.Valid(); it.Next() {
@@ -456,6 +460,7 @@ func TestIterateMultiVersion(t *testing.T) {
 	keyVals := generateKeyValues("key", 4000)
 	skl := buildMultiVersionSkiopList(keyVals)
 	it := skl.NewIterator()
+	defer it.Close()
 	var lastKey y.Key
 	for it.SeekToFirst(); it.Valid(); it.Next() {
 		if !lastKey.IsEmpty() {
@@ -484,6 +489,7 @@ func TestIterateMultiVersion(t *testing.T) {
 		}
 	}
 	revIt := skl.NewUniIterator(true)
+	defer revIt.Close()
 	lastKey.Reset()
 	for revIt.Rewind(); revIt.Valid(); revIt.Next() {
 		if !lastKey.IsEmpty() {

--- a/table/memtable/table.go
+++ b/table/memtable/table.go
@@ -289,3 +289,5 @@ func (it *listNodeIterator) Value() y.ValueStruct { return it.n.entries[it.idx].
 func (it *listNodeIterator) FillValue(vs *y.ValueStruct) { *vs = it.Value() }
 
 func (it *listNodeIterator) Valid() bool { return it.idx >= 0 && it.idx < len(it.n.latestOffs) }
+
+func (it *listNodeIterator) Close() error { return nil }

--- a/table/memtable/table_test.go
+++ b/table/memtable/table_test.go
@@ -35,12 +35,14 @@ func TestListNodeIterator(t *testing.T) {
 		key := newKey(i)
 		require.EqualValues(t, it.Key().UserKey, key)
 	}
+	it.Close()
 	it = ln.newIterator(false)
 	for i := 1; i < 100; i++ {
 		it.Next()
 		key := newKey(i)
 		require.EqualValues(t, it.Key().UserKey, key)
 	}
+	it.Close()
 }
 
 func newKey(i int) []byte {

--- a/table/merge_iterator.go
+++ b/table/merge_iterator.go
@@ -180,6 +180,19 @@ func (mt *MergeIterator) FillValue(vs *y.ValueStruct) {
 	}
 }
 
+// Close implements y.Iterator.
+func (mt *MergeIterator) Close() error {
+	smallerErr := mt.smaller.iter.Close()
+	biggerErr := mt.bigger.iter.Close()
+	if smallerErr != nil {
+		return y.Wrapf(smallerErr, "MergeIterator")
+	}
+	if biggerErr != nil {
+		return y.Wrapf(biggerErr, "MergeIterator")
+	}
+	return nil
+}
+
 // NewMergeIterator creates a merge iterator
 func NewMergeIterator(iters []y.Iterator, reverse bool) y.Iterator {
 	if len(iters) == 0 {
@@ -225,4 +238,8 @@ func (e *EmptyIterator) FillValue(vs *y.ValueStruct) {}
 
 func (e *EmptyIterator) Valid() bool {
 	return false
+}
+
+func (e *EmptyIterator) Close() error {
+	return nil
 }

--- a/table/sstable/iterator.go
+++ b/table/sstable/iterator.go
@@ -77,15 +77,18 @@ type blockIterator struct {
 
 	baseLen uint16
 	ski     singleKeyIterator
+
+	block *block
 }
 
-func (itr *blockIterator) setBlock(b block) {
+func (itr *blockIterator) setBlock(b *block) {
 	itr.err = nil
 	itr.idx = 0
 	itr.key.Reset()
 	itr.val = itr.val[:0]
 	itr.loadEntries(b.data)
 	itr.key.UserKey = append(itr.key.UserKey[:0], b.baseKey[:itr.baseLen]...)
+	itr.block = b
 }
 
 func (itr *blockIterator) valid() bool {
@@ -235,6 +238,7 @@ func (itr *Iterator) seekToFirst() {
 		itr.err = err
 		return
 	}
+	defer block.done()
 	itr.bi.setBlock(block)
 	itr.bi.seekToFirst()
 	itr.err = itr.bi.Error()
@@ -252,6 +256,7 @@ func (itr *Iterator) seekToLast() {
 		itr.err = err
 		return
 	}
+	defer block.done()
 	itr.bi.setBlock(block)
 	itr.bi.seekToLast()
 	itr.err = itr.bi.Error()
@@ -264,6 +269,7 @@ func (itr *Iterator) seekInBlock(blockIdx int, key []byte) {
 		itr.err = err
 		return
 	}
+	defer block.done()
 	itr.bi.setBlock(block)
 	itr.bi.seek(key)
 	itr.err = itr.bi.Error()
@@ -276,6 +282,7 @@ func (itr *Iterator) seekFromOffset(blockIdx int, offset int, key []byte) {
 		itr.err = err
 		return
 	}
+	defer block.done()
 	itr.bi.setBlock(block)
 	itr.bi.setIdx(offset)
 	if bytes.Compare(itr.bi.key.UserKey, key) >= 0 {
@@ -373,11 +380,24 @@ func (itr *Iterator) next() {
 			itr.err = err
 			return
 		}
+		defer block.done()
+		itr.bi.setBlock(block)
+		itr.bi.seekToFirst()
+		itr.err = itr.bi.Error()
+		return
+	} else if ok := itr.bi.block.add(); !ok {
+		block, err := itr.t.block(itr.bpos, itr.tIdx)
+		if err != nil {
+			itr.err = err
+			return
+		}
+		defer block.done()
 		itr.bi.setBlock(block)
 		itr.bi.seekToFirst()
 		itr.err = itr.bi.Error()
 		return
 	}
+	defer itr.bi.block.done()
 
 	itr.bi.next()
 	if !itr.bi.valid() {
@@ -401,11 +421,24 @@ func (itr *Iterator) prev() {
 			itr.err = err
 			return
 		}
+		defer block.done()
+		itr.bi.setBlock(block)
+		itr.bi.seekToLast()
+		itr.err = itr.bi.Error()
+		return
+	} else if ok := itr.bi.block.add(); !ok {
+		block, err := itr.t.block(itr.bpos, itr.tIdx)
+		if err != nil {
+			itr.err = err
+			return
+		}
+		defer block.done()
 		itr.bi.setBlock(block)
 		itr.bi.seekToLast()
 		itr.err = itr.bi.Error()
 		return
 	}
+	defer itr.bi.block.done()
 
 	itr.bi.prev()
 	if !itr.bi.valid() {

--- a/table/sstable/table.go
+++ b/table/sstable/table.go
@@ -398,7 +398,7 @@ func (t *Table) loadIndexData(useMmap bool) (*metaDecoder, error) {
 		}
 		t.indexData = idxData
 	} else {
-		idxData = make([]byte, fstat.Size())
+		idxData = buffer.GetBuffer(int(fstat.Size()))
 		if _, err = t.indexFd.ReadAt(idxData, 0); err != nil {
 			return nil, err
 		}

--- a/table/sstable/table.go
+++ b/table/sstable/table.go
@@ -99,7 +99,13 @@ func (t *Table) Delete() error {
 	}
 	if t.blockCache != nil {
 		for blk := 0; blk < t.numBlocks; blk++ {
-			t.blockCache.Del(t.blockCacheKey(blk))
+			key := t.blockCacheKey(blk)
+			if v, ok := t.blockCache.Get(key); ok {
+				if b, ok := v.(*block); ok {
+					b.done()
+				}
+				t.blockCache.Del(key)
+			}
 		}
 	}
 	if t.indexCache != nil {

--- a/table/sstable/table_test.go
+++ b/table/sstable/table_test.go
@@ -157,6 +157,7 @@ func TestTableIterator(t *testing.T) {
 			require.NoError(t, err)
 			defer table.Delete()
 			it := table.newIterator(false)
+			defer it.Close()
 			count := 0
 			for it.Rewind(); it.Valid(); it.Next() {
 				v := it.Value()
@@ -280,6 +281,7 @@ func TestExternalTable(t *testing.T) {
 	defer table.Delete()
 
 	it := table.newIterator(false)
+	defer it.Close()
 	count := 0
 	for it.Rewind(); it.Valid(); it.Next() {
 		v := it.Value()
@@ -299,6 +301,7 @@ func TestSeekToFirst(t *testing.T) {
 			require.NoError(t, err)
 			defer table.Delete()
 			it := table.newIterator(false)
+			defer it.Close()
 			it.seekToFirst()
 			require.True(t, it.Valid())
 			v := it.Value()
@@ -316,6 +319,7 @@ func TestSeekToLast(t *testing.T) {
 			require.NoError(t, err)
 			defer table.Delete()
 			it := table.newIterator(false)
+			defer it.Close()
 			it.seekToLast()
 			require.True(t, it.Valid())
 			v := it.Value()
@@ -337,6 +341,7 @@ func TestSeekBasic(t *testing.T) {
 	defer table.Delete()
 
 	it := table.newIterator(false)
+	defer it.Close()
 
 	var data = []struct {
 		in    string
@@ -371,6 +376,7 @@ func TestSeekForPrev(t *testing.T) {
 	defer table.Delete()
 
 	it := table.newIterator(false)
+	defer it.Close()
 
 	var data = []struct {
 		in    string
@@ -407,6 +413,7 @@ func TestIterateFromStart(t *testing.T) {
 			require.NoError(t, err)
 			defer table.Delete()
 			ti := table.newIterator(false)
+			defer ti.Close()
 			ti.reset()
 			ti.seekToFirst()
 			require.True(t, ti.Valid())
@@ -433,6 +440,7 @@ func TestIterateFromEnd(t *testing.T) {
 			require.NoError(t, err)
 			defer table.Delete()
 			ti := table.newIterator(false)
+			defer ti.Close()
 			ti.reset()
 			ti.seek([]byte("zzzzzz")) // Seek to end, an invalid element.
 			require.False(t, ti.Valid())
@@ -456,6 +464,7 @@ func TestTable(t *testing.T) {
 	require.NoError(t, err)
 	defer table.Delete()
 	ti := table.newIterator(false)
+	defer ti.Close()
 	kid := 1010
 	seek := y.KeyWithTs([]byte(key("key", kid)), 0)
 	for ti.seek(seek.UserKey); ti.Valid(); ti.next() {
@@ -484,6 +493,7 @@ func TestIterateBackAndForth(t *testing.T) {
 
 	seek := y.KeyWithTs([]byte(key("key", 1010)), 0)
 	it := table.newIterator(false)
+	defer it.Close()
 	it.seek(seek.UserKey)
 	require.True(t, it.Valid())
 	k := it.Key()
@@ -522,6 +532,7 @@ func TestIterateMultiVersion(t *testing.T) {
 	require.NoError(t, err)
 	defer table.Delete()
 	it := table.newIterator(false)
+	defer it.Close()
 	itCnt := 0
 	var lastKey y.Key
 	for it.Rewind(); it.Valid(); it.Next() {
@@ -556,6 +567,7 @@ func TestIterateMultiVersion(t *testing.T) {
 		}
 	}
 	revIt := table.newIterator(true)
+	defer revIt.Close()
 	lastKey.Reset()
 	for revIt.Rewind(); revIt.Valid(); revIt.Next() {
 		if !lastKey.IsEmpty() {
@@ -582,6 +594,7 @@ func TestUniIterator(t *testing.T) {
 	defer table.Delete()
 	{
 		it := table.newIterator(false)
+		defer it.Close()
 		var count int
 		for it.Rewind(); it.Valid(); it.Next() {
 			v := it.Value()
@@ -593,6 +606,7 @@ func TestUniIterator(t *testing.T) {
 	}
 	{
 		it := table.newIterator(true)
+		defer it.Close()
 		var count int
 		for it.Rewind(); it.Valid(); it.Next() {
 			v := it.Value()
@@ -616,6 +630,7 @@ func TestConcatIteratorOneTable(t *testing.T) {
 	defer tbl.Delete()
 
 	it := table.NewConcatIterator([]table.Table{tbl}, false)
+	defer it.Close()
 
 	it.Rewind()
 	require.True(t, it.Valid())
@@ -643,6 +658,7 @@ func TestConcatIterator(t *testing.T) {
 
 	{
 		it := table.NewConcatIterator([]table.Table{tbl, tbl2, tbl3}, false)
+		defer it.Close()
 		it.Rewind()
 		require.True(t, it.Valid())
 		var count int
@@ -674,6 +690,7 @@ func TestConcatIterator(t *testing.T) {
 	}
 	{
 		it := table.NewConcatIterator([]table.Table{tbl, tbl2, tbl3}, true)
+		defer it.Close()
 		it.Rewind()
 		require.True(t, it.Valid())
 		var count int
@@ -724,6 +741,7 @@ func TestMergingIterator(t *testing.T) {
 	it1 := tbl1.newIterator(false)
 	it2 := table.NewConcatIterator([]table.Table{tbl2}, false)
 	it := table.NewMergeIterator([]y.Iterator{it1, it2}, false)
+	defer it.Close()
 
 	it.Rewind()
 	require.True(t, it.Valid())
@@ -764,6 +782,7 @@ func TestMergingIteratorReversed(t *testing.T) {
 	it1 := tbl1.newIterator(true)
 	it2 := table.NewConcatIterator([]table.Table{tbl2}, true)
 	it := table.NewMergeIterator([]y.Iterator{it1, it2}, true)
+	defer it.Close()
 
 	it.Rewind()
 	require.True(t, it.Valid())
@@ -804,6 +823,7 @@ func TestMergingIteratorTakeOne(t *testing.T) {
 	it1 := table.NewConcatIterator([]table.Table{t1}, false)
 	it2 := table.NewConcatIterator([]table.Table{t2}, false)
 	it := table.NewMergeIterator([]y.Iterator{it1, it2}, false)
+	defer it.Close()
 
 	it.Rewind()
 	require.True(t, it.Valid())
@@ -850,6 +870,7 @@ func TestMergingIteratorTakeTwo(t *testing.T) {
 	it1 := table.NewConcatIterator([]table.Table{t1}, false)
 	it2 := table.NewConcatIterator([]table.Table{t2}, false)
 	it := table.NewMergeIterator([]y.Iterator{it1, it2}, false)
+	defer it.Close()
 
 	it.Rewind()
 	require.True(t, it.Valid())
@@ -906,6 +927,7 @@ func TestSeekInvalidIssue(t *testing.T) {
 	require.NoError(t, err)
 	defer t1.Delete()
 	it := t1.NewIterator(false).(*Iterator)
+	defer it.Close()
 	for i := 1; i < it.tIdx.baseKeys.length(); i++ {
 		baseKey := it.tIdx.baseKeys.getEntry(i)
 		idx := sort.Search(len(keys), func(i int) bool {
@@ -929,8 +951,10 @@ func TestOpenImMemoryTable(t *testing.T) {
 	fileTable, err := OpenTable(file.Name(), nil, nil)
 	require.Nil(t, err)
 	inMemIt := inMemTbl.NewIterator(false)
+	defer inMemIt.Close()
 	inMemIt.Rewind()
 	fileIt := fileTable.NewIterator(false)
+	defer fileIt.Close()
 	fileIt.Rewind()
 	for ; fileIt.Valid(); fileIt.Next() {
 		if fileIt.Valid() {
@@ -995,6 +1019,7 @@ func BenchmarkRead(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		func() {
 			it := tbl.newIterator(false)
+			defer it.Close()
 			for it.seekToFirst(); it.Valid(); it.next() {
 			}
 		}()
@@ -1084,6 +1109,7 @@ func BenchmarkPointGet(b *testing.B) {
 				for i := 0; i < n; i++ {
 					k := keys[rand.Intn(n)]
 					it := tbl.newIterator(false)
+					defer it.Close()
 					it.Seek(k.UserKey)
 					if !it.Valid() {
 						continue
@@ -1112,6 +1138,7 @@ func BenchmarkPointGet(b *testing.B) {
 					resultKey, resultVs, ok, _ = tbl.pointGet(k, keyHash)
 					if !ok {
 						it := tbl.newIterator(false)
+						defer it.Close()
 						it.Seek(k.UserKey)
 						if !it.Valid() {
 							continue
@@ -1157,6 +1184,7 @@ func BenchmarkReadAndBuild(b *testing.B) {
 		func() {
 			newBuilder := NewTableBuilder(f, nil, 0, options.TableBuilderOptions{})
 			it := tbl.newIterator(false)
+			defer it.Close()
 			for it.seekToFirst(); it.Valid(); it.next() {
 				vs := it.Value()
 				newBuilder.Add(it.Key(), vs)
@@ -1205,6 +1233,7 @@ func BenchmarkReadMerged(b *testing.B) {
 				iters = append(iters, tbl.newIterator(false))
 			}
 			it := table.NewMergeIterator(iters, false)
+			defer it.Close()
 			for it.Rewind(); it.Valid(); it.Next() {
 			}
 		}()
@@ -1220,6 +1249,7 @@ func BenchmarkRandomRead(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		itr := tbl.newIterator(false)
+		defer itr.Close()
 		no := r.Intn(n)
 		k := []byte(fmt.Sprintf("%016x", no))
 		v := []byte(fmt.Sprintf("%d", no))

--- a/transaction.go
+++ b/transaction.go
@@ -221,6 +221,10 @@ func (pi *pendingWritesIterator) Valid() bool {
 	return pi.nextIdx < len(pi.entries)
 }
 
+func (pi *pendingWritesIterator) Close() error {
+	return nil
+}
+
 func (txn *Txn) newPendingWritesIterator(reversed bool) *pendingWritesIterator {
 	if !txn.update || len(txn.pendingWrites) == 0 {
 		return nil

--- a/value_test.go
+++ b/value_test.go
@@ -365,6 +365,7 @@ func checkKeys(t *testing.T, kv *DB, keys [][]byte) {
 	i := 0
 	txn := kv.NewTransaction(false)
 	iter := txn.NewIterator(IteratorOptions{})
+	defer iter.Close()
 	for iter.Seek(keys[0]); iter.Valid(); iter.Next() {
 		require.Equal(t, iter.Item().Key(), keys[i])
 		i++

--- a/writer_ingest.go
+++ b/writer_ingest.go
@@ -174,6 +174,7 @@ func (w *writeWorker) overlapWithFlushingMemTables(kr keyRange) bool {
 	imms := tbls.tables[:atomic.LoadUint32(&tbls.length)]
 	for _, mt := range imms {
 		it := mt.NewIterator(false)
+		defer it.Close()
 		it.Seek(kr.left.UserKey)
 		if !it.Valid() || it.Key().Compare(kr.right) <= 0 {
 			return true
@@ -206,6 +207,7 @@ func (w *writeWorker) checkRangeInLevel(kr keyRange, level int) (overlappingTabl
 
 	for i := left; i < right; i++ {
 		it := handler.tables[i].NewIterator(false)
+		defer it.Close()
 		it.Seek(kr.left.UserKey)
 		if it.Valid() && it.Key().Compare(kr.right) <= 0 {
 			overlap = true

--- a/writer_ingest.go
+++ b/writer_ingest.go
@@ -72,6 +72,7 @@ func (w *writeWorker) prepareIngestTask(task *ingestTask) (ts uint64, wg *sync.W
 	mTbls := w.mtbls.Load().(*memTables)
 	y.Assert(mTbls.tables[0] != nil)
 	it := mTbls.getMutable().NewIterator(false)
+	defer it.Close()
 	for _, t := range task.tbls {
 		it.Seek(t.Smallest().UserKey)
 		if it.Valid() && it.Key().Compare(t.Biggest()) <= 0 {

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -92,6 +92,7 @@ type Iterator interface {
 	Value() ValueStruct
 	FillValue(vs *ValueStruct)
 	Valid() bool
+	Close() error
 }
 
 // SeekToVersion seeks a valid Iterator to the version that <= the given version.


### PR DESCRIPTION
## Buffer
### Case 1
Key:10
Value:1024
Batch:1024

#### Set
Total entries:10000*1024

|Package|dgraph-io|pingcap|changed|
|:--:|:--|:--|:--|
|Total alloc|172.34GB|34.81GB|31.98GB|
|Block alloc|105.91GB|2.33GB|0.82GB|

#### Get
Total Entries:4096*1024

|Package|dgraph-io|pingcap|changed|
|:--:|:--|:--|:--|
|Total alloc|32.54GB|2.20GB|2.21GB|
|Block alloc|16.43GB|0.27GB|0.28GB|

### Case 2
Key:512
Value:512
Batch:1024

#### Set
Total Entries:10000*1024

|Package|dgraph-io|pingcap|changed|
|:--:|:--|:--|:--|
|Total alloc|220.48GB|84.74GB|40.51GB|
|Block alloc|89.33GB|44.92GB|3.56GB|

#### Get
Total Entries:4096*1024

|Package|dgraph-io|pingcap|changed|
|:--:|:--|:--|:--|
|Total alloc|33.90GB|66.99GB|6.69GB|
|Block alloc|17.32GB|60.10GB|1.06GB|

## Deadlock
debug/pprof/goroutine
```
#	0x106c626	sync.runtime_SemacquireMutex+0x46				/usr/local/go/src/runtime/sema.go:71
#	0x107b8c4	sync.(*RWMutex).Lock+0x84					/usr/local/go/src/sync/rwmutex.go:103
#	0x14b765c	github.com/hslam/badger.(*compactStatus).compareAndAdd+0x5c	/Users/huangmeng/go/src/github.com/hslam/badger/compaction.go:150
#	0x14bad27	github.com/hslam/badger.(*CompactDef).fillTables+0x1347		/Users/huangmeng/go/src/github.com/hslam/badger/compaction.go:457
#	0x14d274f	github.com/hslam/badger.(*levelsController).doCompact+0xc0f	/Users/huangmeng/go/src/github.com/hslam/badger/levels.go:655
#	0x14cda4b	github.com/hslam/badger.(*levelsController).runWorker+0xcb	/Users/huangmeng/go/src/github.com/hslam/badger/levels.go:201

1 @ 0x103b625 0x104bf85 0x104bf6e 0x106c627 0x107b8c5 0x14c958c 0x14d13db 0x14d2029 0x14cda4c 0x10706c1
#	0x106c626	sync.runtime_SemacquireMutex+0x46				/usr/local/go/src/runtime/sema.go:71
#	0x107b8c4	sync.(*RWMutex).Lock+0x84					/usr/local/go/src/sync/rwmutex.go:103
#	0x14c958b	github.com/hslam/badger.(*levelHandler).replaceTables+0x8b	/Users/huangmeng/go/src/github.com/hslam/badger/level_handler.go:152
#	0x14d13da	github.com/hslam/badger.(*levelsController).runCompactDef+0x35a	/Users/huangmeng/go/src/github.com/hslam/badger/levels.go:622
#	0x14d2028	github.com/hslam/badger.(*levelsController).doCompact+0x4e8	/Users/huangmeng/go/src/github.com/hslam/badger/levels.go:664
#	0x14cda4b	github.com/hslam/badger.(*levelsController).runWorker+0xcb	/Users/huangmeng/go/src/github.com/hslam/badger/levels.go:201

1 @ 0x103b625 0x104bf85 0x104bf6e 0x106c627 0x14c85a5 0x14c8538 0x14d2cbb 0x14c4645 0x10706c1
#	0x106c626	sync.runtime_SemacquireMutex+0x46					/usr/local/go/src/runtime/sema.go:71
#	0x14c85a4	sync.(*RWMutex).RLock+0xa4						/usr/local/go/src/sync/rwmutex.go:50
#	0x14c8537	github.com/hslam/badger.(*levelHandler).getTotalSize+0x37		/Users/huangmeng/go/src/github.com/hslam/badger/level_handler.go:52
#	0x14d2cba	github.com/hslam/badger.(*levelsController).addLevel0Table+0x31a	/Users/huangmeng/go/src/github.com/hslam/badger/levels.go:694
#	0x14c4644	github.com/hslam/badger.(*DB).runFlushMemTable+0x464			/Users/huangmeng/go/src/github.com/hslam/badger/db.go:963
```

Circular wait
```
goroutine1:
badger.(*levelsController).runWorker
	badger.(*levelsController).doCompact
		badger.(*CompactDef).fillTables
			badger.(*CompactDef).lockLevels
				badger.(*levelHandler).RLock
			badger.(*compactStatus).compareAndAdd
				badger.(*compactStatus).Lock

goroutine2:
badger.(*levelsController).runWorker
	badger.(*levelsController).doCompact
		badger.(*levelsController).runCompactDef
			badger.(*levelHandler).replaceTables
				badger.(*levelHandler).Lock


goroutine3:
badger.(*DB).runFlushMemTable
	badger.(*levelsController).addLevel0Table
		badger.(*compactStatus).RLock
		badger.(*levelHandler).getTotalSize
			badger.(*levelHandler).RLock
			badger.(*levelHandler).RUnlock
		badger.(*compactStatus).RUnlock
```
Goroutine1 blocks goroutine2.
Goroutine2 blocks goroutine3.
Goroutine3 blocks goroutine1.

Fixed
```
goroutine3:
badger.(*DB).runFlushMemTable
	badger.(*levelsController).addLevel0Table
		badger.(*compactStatus).RLock
		badger.(*compactStatus).RUnlock
		badger.(*levelHandler).getTotalSize
			badger.(*levelHandler).RLock
			badger.(*levelHandler).RUnlock
```

