### PR TITLE
fix windows compile error for directio pkg

### DIFF
--- a/directio/proxy_other.go
+++ b/directio/proxy_other.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Inc.
+// Copyright 2023 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// directio is a proxy package for github.com/pingcap/badger/directio
+//go:build !linux
+
 package directio
 
 import (
 	"github.com/ncw/directio"
 )
 
-const (
-	// AlignSize is the size to align the buffer to
-	AlignSize = directio.AlignSize
-	// BlockSize is the minimum block size
-	BlockSize = directio.BlockSize
-)
-
-// AlignedBlock returns []byte of size BlockSize aligned to a multiple
-// of AlignSize in memory (must be power of two)
-var AlignedBlock = directio.AlignedBlock
+// TODO: check the errors and fallback for the systems besides linux
+var OpenFile = directio.OpenFile


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

The directio pkg uses `unix.EINVAL`, which doesn't exit in windows. To support windows, I'd add a compilation flag and use the original directio directly.

I also find that the errors returned in the darwin and openbsd is different with Linux. In Linux, it returns the return the EINVAL (directly by the system call). For darwin, it's a software defined "Failed to set F_NOCACHE: %s". The windows seems to be more complicated. As I don't have a Mac OS / Windows device, I left it here to return the result directly.  

Actually, I'm not sure whether there are file systems like tmpfs which don't support direct io in Mac OS and other systems.